### PR TITLE
Fix skip detection for RSpec examples

### DIFF
--- a/lib/ci_logger/railtie.rb
+++ b/lib/ci_logger/railtie.rb
@@ -21,7 +21,7 @@ module CiLogger
           config.append_after do |example|
             if !Rails.application.config.ci_logger.enabled
               Rails.logger.sync
-            elsif passed? || skipped?
+            elsif passed? || example.skipped?
               Rails.logger.clear
             else
               Rails.logger.debug("finish example at #{example.location}")


### PR DESCRIPTION
Thank you for developing ci_logger

In my pipeline, the following error occurred:
```
undefined method `skipped?' for #<RSpec::ExampleGroups...
```

https://github.com/willnet/ci_logger/blob/1f2dc4cbf8dad66d5dca85a8aca6ee6010463eba/lib/ci_logger/railtie.rb#L24

It seems that the receiver of this `skipped?` should be `Example`not `ExampleGroup`.


https://github.com/willnet/ci_logger/blob/1f2dc4cbf8dad66d5dca85a8aca6ee6010463eba/test/rspec_integration_test.rb#L33-L41

This test is passing. For some reason `ExampleGroup` has a `skipped?` method that consistently returns nil, which prevents an `undefined method` error. However, I was unable to identify the root cause 🙇 

