### PR TITLE
Fix undefined method `skipped?'

### DIFF
--- a/lib/ci_logger/railtie.rb
+++ b/lib/ci_logger/railtie.rb
@@ -21,7 +21,7 @@ module CiLogger
           config.append_after do |example|
             if !Rails.application.config.ci_logger.enabled
               Rails.logger.sync
-            elsif passed? || skipped?
+            elsif passed?
               Rails.logger.clear
             else
               Rails.logger.debug("finish example at #{example.location}")

--- a/test/rspec_integration_test.rb
+++ b/test/rspec_integration_test.rb
@@ -30,11 +30,20 @@ class RspecIntegrationTest < ActiveSupport::TestCase
     assert File.empty?(LOGFILE_PATH)
   end
 
-  test "failure test write logs on CiLogger enabled" do
+  test "failure request spec write logs on CiLogger enabled" do
     group = RSpec.describe 'hello', type: :request
     group.example do
       get '/users'
       expect(response.status).to eq 500
+    end
+    group.run(@reporter)
+    assert_not File.empty?(LOGFILE_PATH)
+  end
+
+  test "failure model spec write logs on CiLogger enabled" do
+    group = RSpec.describe 'hello', type: :model
+    group.example do
+      expect(true).to eq false
     end
     group.run(@reporter)
     assert_not File.empty?(LOGFILE_PATH)


### PR DESCRIPTION
Related PR #10

We used `passed? || skipped?` condition in reference to system test screenshot ( https://github.com/rails/rails/blob/bccf42baf877774f7f8cd3a7a41aa974af5b9939/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb#L136-L138 ). But this way was not appropriate for RSpec.

ExampleGroup in System Spec or Request Spec can call `skipped?` method, but it always returns nil if we skip the example.

We can remove `skipped?` because  `passed?` returns true if we skip the example.
