### PR TITLE
Enable to replace loggers besides rails logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ config.ci_logger.enabled = ENV['CI']
 
 You can replace `ENV['CI']` with what you like.
 
+## Replace loggers besides rails logger
+
+CiLogger replaces Rails.logger by default, but other loggers can be replaced.
+
+```ruby
+your_logger = CiLogger::Logger.new(your_logger)
+your_logger.debug('debug!') # This is only output when the test fails
+```
+
 ## Contributing
 Contribution directions go here.
 

--- a/lib/ci_logger/logger.rb
+++ b/lib/ci_logger/logger.rb
@@ -1,3 +1,5 @@
+require "ci_logger/registry"
+
 module CiLogger
   class Logger < ::Logger
     def initialize(original)
@@ -5,6 +7,7 @@ module CiLogger
       @original_level = @original.level
       @original.level = :debug
       self.level = :debug
+      Registry.register(self)
     end
 
     def sync

--- a/lib/ci_logger/minitest/integration.rb
+++ b/lib/ci_logger/minitest/integration.rb
@@ -4,11 +4,11 @@ module CiLogger
       def before_teardown
         super
         if !Rails.application.config.ci_logger.enabled
-          Rails.logger.sync
+          Registry.sync
         elsif passed? || skipped?
-          Rails.logger.clear
+          Registry.clear
         else
-          Rails.logger.sync
+          Registry.sync
         end
       end
     end

--- a/lib/ci_logger/registry.rb
+++ b/lib/ci_logger/registry.rb
@@ -1,0 +1,22 @@
+module CiLogger
+  module Registry
+    class << self
+      def register(logger)
+        @loggers ||= []
+        @loggers << logger
+      end
+
+      def sync
+        @loggers.each(&:sync)
+      end
+
+      def clear
+        @loggers.each(&:clear)
+      end
+
+      def debug(...)
+        @loggers.each { _1.debug(...) }
+      end
+    end
+  end
+end

--- a/lib/ci_logger/rspec/integration.rb
+++ b/lib/ci_logger/rspec/integration.rb
@@ -6,17 +6,17 @@ RSpec.configure do |config|
   config.prepend_before do |example|
     next unless Rails.application.config.ci_logger.enabled
 
-    Rails.logger.debug("start example at #{example.location}")
+    CiLogger::Registry.debug("start example at #{example.location}")
   end
 
   config.append_after do |example|
     if !Rails.application.config.ci_logger.enabled
-      Rails.logger.sync
+      CiLogger::Registry.sync
     elsif passed?
-      Rails.logger.clear
+      CiLogger::Registry.clear
     else
-      Rails.logger.debug("finish example at #{example.location}")
-      Rails.logger.sync
+      CiLogger::Registry.debug("finish example at #{example.location}")
+      CiLogger::Registry.sync
     end
   end
 end

--- a/test/registry_test.rb
+++ b/test/registry_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class RegistryTest < ActiveSupport::TestCase
+  LOGFILE_PATH_1 = '/tmp/ciloggertest_1.log'
+  LOGFILE_PATH_2 = '/tmp/ciloggertest_2.log'
+
+  setup do
+    log1 = Logger.new(LOGFILE_PATH_1)
+    log2 = Logger.new(LOGFILE_PATH_2)
+    @logger1 = CiLogger::Logger.new(log1)
+    @logger2 = CiLogger::Logger.new(log2)
+  end
+
+  test "Registry#sync syncs all registered loggers" do
+    @logger1.debug 'ci_logger1'
+    @logger2.debug 'ci_logger2'
+    CiLogger::Registry.sync
+    assert File.read(LOGFILE_PATH_1).match?('ci_logger1')
+    assert File.read(LOGFILE_PATH_2).match?('ci_logger2')
+  end
+
+  test "Registry#debug calls debug method of all registered loggers" do
+    mock1 = Minitest::Mock.new.expect(:call, nil, ['ci_logger!'])
+    mock2 = Minitest::Mock.new.expect(:call, nil, ['ci_logger!'])
+    @logger1.stub(:debug, mock1) do
+      @logger2.stub(:debug, mock2) do
+        CiLogger::Registry.debug('ci_logger!')
+      end
+    end
+
+    mock1.verify
+    mock2.verify
+  end
+
+  teardown do
+    CiLogger::Registry.clear
+    File.unlink(LOGFILE_PATH_1)
+    File.unlink(LOGFILE_PATH_2)
+  end
+end


### PR DESCRIPTION
CiLogger replaces Rails.logger by default, but other loggers can be replaced.

```ruby
your_logger = CiLogger::Logger.new(your_logger)
your_logger.debug('debug!') # This is only output when the test fails
```
