### PR TITLE
Stop inheriting from Logger

### DIFF
--- a/lib/ci_logger/logger.rb
+++ b/lib/ci_logger/logger.rb
@@ -1,47 +1,21 @@
 require "ci_logger/registry"
 
 module CiLogger
-  class Logger < ::Logger
+  class Logger
     def initialize(original)
       @original = original
-      @original_level = @original.level
-      @original.level = :debug
-      self.level = :debug
       Registry.register(self)
     end
 
     def sync
       temporary_log.each do |l|
-        if @level <= l[:severity]
-          @original.add(l[:severity], l[:message], l[:progname])
-        end
+        @original.add(l[:severity], l[:message], l[:progname])
       end
       temporary_log.clear
     end
 
-    def sync_with_original_level
-      @original.level = @original_level
-      sync
-    ensure
-      @original.level = :debug
-    end
-
     def clear
       temporary_log.clear
-    end
-
-    def formatter
-      @original.formatter
-    end
-
-    def formatter=(f)
-      @original.formatter = f
-    end
-
-    private
-
-    def temporary_log
-      @temporary_log ||= []
     end
 
     def add(severity, message = nil, progname = nil)
@@ -59,12 +33,42 @@ module CiLogger
       temporary_log << { severity: severity, message: message, progname: progname }
     end
 
-    def method_missing(symbol, *args, &block)
-      @original.send(symbol, *args, &block)
+    def debug(progname = nil, &block)
+      add(::Logger::DEBUG, nil, progname, &block)
     end
 
-    def respond_to_missing?(symbol, include_all)
-      @original.respond_to?(symbol, include_all)
+    def info(progname = nil, &block)
+      add(::Logger::INFO, nil, progname, &block)
+    end
+
+    def warn(progname = nil, &block)
+      add(::Logger::WARN, nil, progname, &block)
+    end
+
+    def error(progname = nil, &block)
+      add(::Logger::ERROR, nil, progname, &block)
+    end
+
+    def fatal(progname = nil, &block)
+      add(::Logger::FATAL, nil, progname, &block)
+    end
+
+    def unknown(progname = nil, &block)
+      add(::Logger::UNKNOWN, nil, progname, &block)
+    end
+
+    private
+
+    def temporary_log
+      @temporary_log ||= []
+    end
+
+    def method_missing(...)
+      @original.send(...)
+    end
+
+    def respond_to_missing?(...)
+      @original.respond_to?(...)
     end
   end
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -20,48 +20,38 @@ class LoggerTest < ActiveSupport::TestCase
     File.unlink(LOGFILE_PATH)
   end
 
-  test "CiLogger::Logger#debug doesn't output immediately" do
-    @logger.debug 'ci_logger!'
+  test "CiLogger::Logger#info doesn't output immediately" do
+    @logger.info 'ci_logger!'
 
     assert_not File.read(LOGFILE_PATH).match?('ci_logger!')
   end
 
   test "CiLogger::Logger#sync output before it write" do
-    @logger.debug 'ci_logger!'
+    @logger.info 'ci_logger!'
     @logger.sync
     assert File.read(LOGFILE_PATH).match?('ci_logger!')
   end
 
   test "CiLogger::Logger supports block" do
-    @logger.debug do
+    @logger.info do
       'ci_logger!'
     end
     @logger.sync
     assert File.read(LOGFILE_PATH).match?('ci_logger!')
   end
 
-  test "CiLogger::Logger#sync doesn't output log if it's loglevel is lower than setting" do
-    @logger.level = :info
+  test "CiLogger::Logger#sync doesn't output log if original loglevel is higher" do
     @logger.debug 'ci_logger!'
     @logger.sync
     assert_not File.read(LOGFILE_PATH).match?('ci_logger!')
   end
 
-  test "CiLogger::Logger#sync_with_original_level output before it write if it's level is equal or higher than original logger's one" do
-    @logger.debug 'ci_logger!'
-    @logger.info 'hello!'
-    @logger.sync_with_original_level
-    log = File.read(LOGFILE_PATH)
-    assert_not log.match?('ci_logger!')
-    assert log.match?('hello!')
-  end
-
   test "CiLogger::Logger accepts methods original logger has" do
     # tagged is a extension method of the Rails Logger
-    Rails.logger.tagged('hello') { |l| l.debug('world') }
+    Rails.logger.tagged('hello') { |l| l.info('world') }
   end
 
-  test "CiLogger::Logger delegates formatter to original logger" do
+  test "CiLogger::Logger uses formatter that original logger has" do
     assert_equal 'hoge', @logger.formatter.hoge
   end
 end


### PR DESCRIPTION
Fix #18

CiLogger::Logger should delegate everything to the original Logger except the methods to write to the Logger, but we have been using inheritance to get the Logger interface quickly at the beginning.
