### PR TITLE
Change CiLogger wrapping target to individual loggers of ActiveSupport::BroadcastLogger

### DIFF
--- a/lib/ci_logger/railtie.rb
+++ b/lib/ci_logger/railtie.rb
@@ -5,7 +5,14 @@ module CiLogger
 
     config.before_initialize do
       if CiLogger.enabled?
-        Rails.logger = CiLogger::Logger.new(Rails.logger)
+        if defined?(ActiveSupport::BroadcastLogger) && Rails.logger.is_a?(ActiveSupport::BroadcastLogger)
+          Rails.logger.instance_variable_get(:@broadcasts).map! do |logger|
+            CiLogger::Logger.new(logger)
+          end
+        else
+          Rails.logger = CiLogger::Logger.new(Rails.logger)
+        end
+
         begin
           require "rspec/core"
           require "ci_logger/rspec/integration"

--- a/test/rails_integration_test.rb
+++ b/test/rails_integration_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class RailsIntegrationTest < ActiveSupport::TestCase
+  if Rails.gem_version >= Gem::Version.new('7.1')
+    test "Rails.logger is a BroadcastLogger and it has instances of CiLogger" do
+      assert Rails.logger.is_a?(ActiveSupport::BroadcastLogger)
+      assert Rails.logger.instance_variable_get(:@broadcasts).all? { |logger| logger.is_a?(CiLogger::Logger) }
+    end
+  else
+    test "Rails.logger is an CiLogger" do
+      assert Rails.logger.is_a?(CiLogger::Logger)
+    end
+  end
+end


### PR DESCRIPTION
Previously, CiLogger was designed to wrap Rails.logger directly. However, starting from Rails 7.1, ActiveSupport::BroadcastLogger has been introduced and set as the default for Rails.logger.

This commit changes our approach by wrapping the individual loggers within BroadcastLogger with CiLogger instead of wrapping BroadcastLogger itself. This enhancement enables more flexible logging options, such as allowing logs to be output in all contexts in addition to the ones specifically for test failures.

```ruby
# config/environments/test.rb

config.after_initialize do
  all_logger = Logger.new("all.log")
  Rails.logger.broadcast_to(all_logger)
end
```

Additionally, this change addresses issues related to type expectations for Rails.logger when ActiveSupport::BroadcastLogger is configured, improving compatibility with certain libraries (e.g., [Vonage Ruby SDK](https://github.com/Vonage/vonage-ruby-sdk/blob/ae6a36e2141fde54a21afe9369b436d50e799880/lib/vonage/logger.rb#L12) )